### PR TITLE
Change to offset, size

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,12 @@ Spec for the structure required by ReferenceFileSystem:
 {
   "key0": "data",
   "key1": {
-    ["protocol://target_url", 100, 200]
+    ["protocol://target_url", 100, 100]
   }
 }
 ```
 
-where "key0" includes data as-is (stored as text), and "key1" refers to the given remote URL, the set of bytes
-between the given start-stop values (start is inclusive, end is not, as is typical for python).
+where "key0" includes data as-is (stored as text), and "key1" refers to the given remote URL, the offset within the file (in bytes), and the length of the data item (in bytes).
 
 For example, zarr data might be stored like
 
@@ -24,6 +23,6 @@ For example, zarr data might be stored like
   ".zattrs": "{\n    \"Conventions\": \"UGRID-0.9.0\n\"},
   "x/.zattrs": "{\n    \"_ARRAY_DIMENSIONS\": [\n        \"node\"\n ...",
   "x/.zarray": "{\n    \"chunks\": [\n        9228245\n    ],\n    \"compressor\": null,\n    \"dtype\": \"<f8\",\n  ...",
-  "x/0": ["s3://bucket/path/file.nc", 294094376, 367920336]
+  "x/0": ["s3://bucket/path/file.nc", 294094376, 73825960]
 },
 ```


### PR DESCRIPTION
As discussed in #4, the preference from the community seems to be for `offset, size` instead of `start, stop` for encoding item locations within a file.