### PR TITLE
Adding example notebook with binder link

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,5 +29,5 @@ For example, Zarr data in this proposed spec might be represented as:
 ```
 
 
-Run a notebook example comparing reading HDF5 using this approach vs. native Zarr format:
-[![Binder](https://aws-uswest2-binder.pangeo.io/badge_logo.svg)](https://aws-uswest2-binder.pangeo.io/v2/gh/rsignell-usgs/fsspec-reference-maker/example?filepath=examples%2Fike_intake.ipynb)
+
+[![Binder](https://aws-uswest2-binder.pangeo.io/badge_logo.svg)](https://aws-uswest2-binder.pangeo.io/v2/gh/rsignell-usgs/fsspec-reference-maker/example?filepath=examples%2Fike_intake.ipynb): Run a notebook example comparing reading HDF5 using this approach vs. native Zarr format

--- a/README.md
+++ b/README.md
@@ -29,5 +29,4 @@ For example, Zarr data in this proposed spec might be represented as:
 ```
 
 
-Click here to run a notebook comparing reading HDF5 with Zarr, using this approach:
-[![Binder](https://aws-uswest2-binder.pangeo.io/badge_logo.svg)](https://aws-uswest2-binder.pangeo.io/v2/gh/rsignell-usgs/fsspec-reference-maker/example?filepath=examples%2Fike_intake.ipynb)
+Run a notebook example comparing reading HDF5 using this approach vs. native Zarr format:[![Binder](https://aws-uswest2-binder.pangeo.io/badge_logo.svg)](https://aws-uswest2-binder.pangeo.io/v2/gh/rsignell-usgs/fsspec-reference-maker/example?filepath=examples%2Fike_intake.ipynb)

--- a/README.md
+++ b/README.md
@@ -30,4 +30,5 @@ For example, Zarr data in this proposed spec might be represented as:
 
 
 
-[![Binder](https://aws-uswest2-binder.pangeo.io/badge_logo.svg)](https://aws-uswest2-binder.pangeo.io/v2/gh/rsignell-usgs/fsspec-reference-maker/example?filepath=examples%2Fike_intake.ipynb): Run a notebook example comparing reading HDF5 using this approach vs. native Zarr format
+Run a notebook example comparing reading HDF5 using this approach vs. native Zarr format: <br> 
+[![Binder](https://aws-uswest2-binder.pangeo.io/badge_logo.svg)](https://aws-uswest2-binder.pangeo.io/v2/gh/rsignell-usgs/fsspec-reference-maker/example?filepath=examples%2Fike_intake.ipynb)

--- a/README.md
+++ b/README.md
@@ -29,4 +29,5 @@ For example, Zarr data in this proposed spec might be represented as:
 ```
 
 
-Run a notebook example comparing reading HDF5 using this approach vs. native Zarr format:[![Binder](https://aws-uswest2-binder.pangeo.io/badge_logo.svg)](https://aws-uswest2-binder.pangeo.io/v2/gh/rsignell-usgs/fsspec-reference-maker/example?filepath=examples%2Fike_intake.ipynb)
+Run a notebook example comparing reading HDF5 using this approach vs. native Zarr format:
+[![Binder](https://aws-uswest2-binder.pangeo.io/badge_logo.svg)](https://aws-uswest2-binder.pangeo.io/v2/gh/rsignell-usgs/fsspec-reference-maker/example?filepath=examples%2Fike_intake.ipynb)

--- a/README.md
+++ b/README.md
@@ -29,4 +29,5 @@ For example, Zarr data in this proposed spec might be represented as:
 ```
 
 
+Click here to run a notebook comparing reading HDF5 with Zarr, using this approach:
 [![Binder](https://aws-uswest2-binder.pangeo.io/badge_logo.svg)](https://aws-uswest2-binder.pangeo.io/v2/gh/rsignell-usgs/fsspec-reference-maker/example?filepath=examples%2Fike_intake.ipynb)

--- a/README.md
+++ b/README.md
@@ -27,3 +27,6 @@ For example, Zarr data in this proposed spec might be represented as:
   "x/0": ["s3://bucket/path/file.nc", 294094376, 73825960]
 },
 ```
+
+
+[![Binder](https://aws-uswest2-binder.pangeo.io/badge_logo.svg)](https://aws-uswest2-binder.pangeo.io/v2/gh/rsignell-usgs/fsspec-reference-maker/example?filepath=examples%2Fike_intake.ipynb)

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -3,13 +3,15 @@ channels:
   - defaults
 dependencies:
   - python=3.8
-  - xarray
+  - dask
+  - dask-gateway
   - fsspec
-  - zarr
-  - s3fs
   - intake
   - intake-xarray
   - pip
+  - s3fs
+  - xarray
+  - zarr
   - pip:
       - "git+https://github.com/intake/filesystem_spec"
       - "git+https://github.com/dask/s3fs"

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,0 +1,15 @@
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.8
+  - xarray
+  - fsspec
+  - zarr
+  - s3fs
+  - intake
+  - intake-xarray
+  - pip
+  - pip:
+      - "git+https://github.com/intake/filesystem_spec"
+      - "git+https://github.com/dask/s3fs"

--- a/examples/ike_intake.ipynb
+++ b/examples/ike_intake.ipynb
@@ -56,9 +56,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ds1  = cat['ike-hdf5'].to_dask()\n",
-    "print(ds1.zeta.encoding,'\\n')\n",
-    "ds1.zeta"
+    "ds_hdf5  = cat['ike-hdf5'].to_dask()\n",
+    "print(ds_hdf5.zeta.encoding,'\\n')\n",
+    "ds_hdf5.zeta"
    ]
   },
   {
@@ -74,9 +74,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ds2  = cat['ike-zarr'].to_dask()\n",
-    "print(ds2.zeta.encoding,'\\n')\n",
-    "ds2.zeta"
+    "ds_zarr  = cat['ike-zarr'].to_dask()\n",
+    "print(ds_zarr.zeta.encoding,'\\n')\n",
+    "ds_zarr.zeta"
    ]
   },
   {
@@ -126,10 +126,14 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
    "source": [
-    "Compute the max water level at each grid cell (reads all the data):"
+    "client"
    ]
   },
   {
@@ -139,7 +143,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "max_var1 = ds1['zeta'].max(dim='time').compute()"
+    "max_hdf5 = ds_hdf5['zeta'].max(dim='time').compute()"
    ]
   },
   {
@@ -149,7 +153,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "max_var2 = ds2['zeta'].max(dim='time').compute()"
+    "max_zarr = ds_zarr['zeta'].max(dim='time').compute()"
    ]
   },
   {
@@ -165,7 +169,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "max_var1[1000].values"
+    "max_hdf5[1000].values"
    ]
   },
   {
@@ -174,15 +178,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "max_var2[1000].values"
+    "max_zarr[1000].values"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:zarr-hdf5]",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-zarr-hdf5-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -194,7 +198,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.8.5"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/examples/ike_intake.ipynb
+++ b/examples/ike_intake.ipynb
@@ -1,0 +1,3238 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Read time comparison: Zarr vs HDF5 \n",
+    "Compute the maximum water level during Hurricane Ike on a 9 million node triangular mesh storm surge model (this reads 53GB of data). The data was stored in both Zarr format and as NetCDF4/HDF5, using 11MB chunks with no filters and zlib (level 5) compression.  \n",
+    "\n",
+    "Instead of reading the NetCDF4/HDF5 file with an HDF5 or NetCDF4 library, we extract the metadata into an fsspec referenceFileSystem file, create a mapper, and then read the mapper using the Zarr library.\n",
+    "\n",
+    "Using a cluster with 60 cores, we find that the performance between this read approach and reading native Zarr is not significantly different.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import xarray as xr\n",
+    "import zarr\n",
+    "import fsspec\n",
+    "import fsspec.implementations.reference as refs\n",
+    "import intake\n",
+    "import intake_xarray"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Open Intake Catalog"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cat = intake.open_catalog('intake_catalog.yml')\n",
+    "list(cat)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Zarr library reading HDF5 file with fsspec"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds1  = cat['ike-hdf5'].to_dask()\n",
+    "print(ds1.zeta.encoding,'\\n')\n",
+    "ds1.zeta"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Zarr library reading equivalent Zarr format dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds2  = cat['ike-zarr'].to_dask()\n",
+    "print(ds2.zeta.encoding,'\\n')\n",
+    "ds2.zeta"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Start a dask cluster to crunch the data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dask.distributed import Client\n",
+    "from dask_gateway import Gateway\n",
+    "gateway = Gateway()\n",
+    "cluster = gateway.new_cluster()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cluster.scale(30);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cluster"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = Client(cluster)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Compute the max water level at each grid cell (reads all the data):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "max_var1 = ds1['zeta'].max(dim='time').compute()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "max_var2 = ds2['zeta'].max(dim='time').compute()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### compare a point from both datasets, should be the same"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "max_var1[1000].values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "max_var2[1000].values"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:zarr-hdf5]",
+   "language": "python",
+   "name": "conda-env-zarr-hdf5-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.6"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {
+     "0008329a8dc3413abe5d31cede51428d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_9cf762cbf5e846bba0f9c018e6971471",
+       "style": "IPY_MODEL_7acb0730a5f84604b97333000034a1af",
+       "value": "<p><b>Dashboard: </b><a href=\"/user/rsignell-usgs-h-ke-water-levels-6pu2oezq/proxy/8787/status\" target=\"_blank\">/user/rsignell-usgs-h-ke-water-levels-6pu2oezq/proxy/8787/status</a></p>\n"
+      }
+     },
+     "01fcfe3453574be4ac3d37e28425d0b0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_fad4f62c9399419993153fb961830488",
+        "IPY_MODEL_bdfc56e2940c4c739ff1d5faeec40d7f",
+        "IPY_MODEL_14478fbdfc0a4fa9a41fb87209cfb76b"
+       ],
+       "layout": "IPY_MODEL_dc161608c8bc4a019de49bad6cc0cb2f"
+      }
+     },
+     "02bcdb22428b4e29a02d2f501fa59ad1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonStyleModel",
+      "state": {}
+     },
+     "04d2019b2c424e49ad84be438b76ec89": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "05168f616c1a488bac2900443e8791fd": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "min_width": "500px"
+      }
+     },
+     "061e3b19ad0944bb98c6b44bd10a989c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "06deec34f1f64fad83e521f98f800297": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_33984c4cc18648a5b0958576e913624c",
+       "style": "IPY_MODEL_593b31b05bdf41629cfcd8b01d343fe3",
+       "value": "\n<div>\n  <style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n  </style>\n  <table style=\"text-align: right;\">\n    <tr> <th>Workers</th> <td>23 / 30</td></tr>\n    <tr> <th>Cores</th> <td>46</td></tr>\n    <tr> <th>Memory</th> <td>161.00 GB</td></tr>\n  </table>\n</div>\n"
+      }
+     },
+     "077d5c2a0d3546dcaf5c52166fe1f22b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "IntTextModel",
+      "state": {
+       "description": "Workers",
+       "layout": "IPY_MODEL_c67f4247184e4514bf974e14df8ae7a9",
+       "step": 1,
+       "style": "IPY_MODEL_99af29a9becd4dc3afbf800522d97026"
+      }
+     },
+     "07b39ec7f9984d4d975a83e143dc6172": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "IntTextModel",
+      "state": {
+       "description": "Maximum",
+       "layout": "IPY_MODEL_3ca434c698bb4a888a54af6427e3a4c7",
+       "step": 1,
+       "style": "IPY_MODEL_ae3338f3970a4c7bb0b7ac615a5238ae"
+      }
+     },
+     "07d213ec9c774483937f447bf3dd86ae": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_f860565f03c9460a9fcd197828d4a043",
+       "max": 1,
+       "style": "IPY_MODEL_86cda597474343f990730a66d71dce98",
+       "value": 1
+      }
+     },
+     "08c0039c039d4136abae1a23fe6dfa50": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonStyleModel",
+      "state": {}
+     },
+     "0a1f3eab748f479c9acba6cb99eebe32": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "min_width": "150px"
+      }
+     },
+     "0b019f9ea9864ec898ba7f25f6d2c246": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "0c3940b2272948a1b9dd0b7ce7901cf3": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "0cf8bb6e1c1a4bd2bb9f4d40e537dad4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "12f2b49508b1442e9949f40d582330db": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "min_width": "150px"
+      }
+     },
+     "13c18d134d3e495b9dff310d81b0c2cc": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_fbf901b76b014589bcd19fb800b66b6a",
+        "IPY_MODEL_5b148f98c7da47678f5e38de89b5c215",
+        "IPY_MODEL_e667ec2530bb4d9bb801700b164a1ccf"
+       ],
+       "layout": "IPY_MODEL_6d01a84902be460aa27a72b0da24383a"
+      }
+     },
+     "14478fbdfc0a4fa9a41fb87209cfb76b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_6b3abb3e1d9f4a9685960ac30e86037b",
+       "style": "IPY_MODEL_4f1f297a1c524a489d284d1f5ebf9f18",
+       "value": "<div style=\"padding: 0px 10px 0px 10px; text-align:left; word-wrap: break-word;\">nanmax</div>"
+      }
+     },
+     "14511e290cdf43bab1a81c656bf0aefc": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "14dc93d05a154953b0b1e03ed9c2feac": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "14fdab47ae8c404c9731a2d015bf7fee": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_c15eb2b3ca8847d9b1af872e019583f4",
+        "IPY_MODEL_cf0a449cea2046f6a33ca2007eee69de",
+        "IPY_MODEL_55e8e8ae71f041d1a3eaa0cf6b848642"
+       ],
+       "layout": "IPY_MODEL_8c6015c3d7604e698318912f87530bab"
+      }
+     },
+     "15523fb1e0374bc39a3c50390d11f35c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "15e58519bb39487596d838ec8c190681": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "16786dadcea8412195bede48e8d110d4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_14511e290cdf43bab1a81c656bf0aefc",
+       "style": "IPY_MODEL_77694b68b009421b95468e726e6c00fc",
+       "value": "<div style=\"padding: 0px 10px 0px 10px; text-align:left; word-wrap: break-word;\">nanmax-aggregate</div>"
+      }
+     },
+     "17a5a7909be44a47ade2682ea53a7d22": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "min_width": "150px"
+      }
+     },
+     "17a6ed6ba13647c390a2823596970f1d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "17ab0b12d9d447c1b717ebe23db3a957": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "181fdc531a124868a68a2e2890827375": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "VBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_7e8f27ed66e24f45abcb2462a9cf0a7e",
+        "IPY_MODEL_9808942a2590498abd85f56a1b39309e",
+        "IPY_MODEL_0008329a8dc3413abe5d31cede51428d"
+       ],
+       "layout": "IPY_MODEL_9870b2d3347c44e3b117f5a40d66e8e3"
+      }
+     },
+     "188743e690f84d7c98d69fe1d4504c3f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "min_width": "500px"
+      }
+     },
+     "190f03aa85f84e46bdb44e1a12cdf55e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "198337771f7144b2b69c255c49ed3e2a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "1996e83e6d904ef7a2c1bf43d38d42c3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_57c14ee7bbc146968b56a663d244f14a",
+        "IPY_MODEL_b2a579754a504fde952923508b4d0a23",
+        "IPY_MODEL_c9a79aebecfe4caab349cbf4de843939"
+       ],
+       "layout": "IPY_MODEL_7b7214679e364be2a633f71469a65f61"
+      }
+     },
+     "19cbd86344b74600a4361f37f842e212": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_45658eda13a14b1d86467a7a72fd3677",
+       "style": "IPY_MODEL_9f9365f1a78548de9e8ef23ec2c31c5f",
+       "value": "<p><b>Dashboard: </b><a href=\"/user/rsignell-usgs-h-ke-water-levels-fgcwgixn/proxy/8787/status\" target=\"_blank\">/user/rsignell-usgs-h-ke-water-levels-fgcwgixn/proxy/8787/status</a></p>\n"
+      }
+     },
+     "1a5bac5913d54bcb92b88f27fa8ad3e3": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "1a6617309a5f41f697b30c0126ab903a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "min_width": "500px"
+      }
+     },
+     "1afdd05f0cbc4adabfe91d337e2ce3a4": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "1b0bd764f1974f2ca5bb310fe9208708": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonStyleModel",
+      "state": {}
+     },
+     "1c8a8108a8074d60bcca05d85424d9ec": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "1d7ed0d13a054956865a9a3b14b70af0": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "1ea66a93d68e4731ad555f47a3cc8d8c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "IntTextModel",
+      "state": {
+       "description": "Minimum",
+       "layout": "IPY_MODEL_2316459c1dcb4a2f851b30f4ae87e418",
+       "step": 1,
+       "style": "IPY_MODEL_732f93ed8a0544e89ea131b882079f09"
+      }
+     },
+     "201df16f02724c9dba5408868470de3a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "20a8bb4121724332a556e3906aa1bbd7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "21ff3afbbcbe4f9a92819add7599d64b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "2316459c1dcb4a2f851b30f4ae87e418": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "width": "150px"
+      }
+     },
+     "2334dd91646348518ceb0c8e50675c19": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "23bb3d9707fa4c8a93ddf58993391234": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "IntTextModel",
+      "state": {
+       "description": "Maximum",
+       "layout": "IPY_MODEL_5b31bbf7e7a242b7ab389aad391f887b",
+       "step": 1,
+       "style": "IPY_MODEL_74b82189e5454a4a995f2f866c3fc2c0"
+      }
+     },
+     "254e3a2e6d2047c9ad8afbc2a2e894dc": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "2587b46f1029494593df370baf3af340": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_1d7ed0d13a054956865a9a3b14b70af0",
+       "max": 1,
+       "style": "IPY_MODEL_258ed3d3f27549d7818005f6b52449c2",
+       "value": 1
+      }
+     },
+     "258ed3d3f27549d7818005f6b52449c2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "25a84c261f0b452caf25a81a088ba369": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "290d0f4b92f4483ca42ece3d69c9a8df": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "2afdd253f91d4f2699d8e8304c08d6cd": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "VBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_51815c4353524c2a8b8beaac913c84b4",
+        "IPY_MODEL_01fcfe3453574be4ac3d37e28425d0b0",
+        "IPY_MODEL_eb8414bf255d4b11b91ff378ca44a033",
+        "IPY_MODEL_13c18d134d3e495b9dff310d81b0c2cc"
+       ],
+       "layout": "IPY_MODEL_ed98307e48a348e2a2c20060a8c47bce"
+      }
+     },
+     "2ec6202a874e4e72a4d4f0a12ef242a0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_6a2667550c2a4cb482f515799355737f",
+        "IPY_MODEL_6090404403a64908b5a555c061e72a50"
+       ],
+       "layout": "IPY_MODEL_1a5bac5913d54bcb92b88f27fa8ad3e3"
+      }
+     },
+     "311f02a5b5e24d3d8509c82e28be4563": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonModel",
+      "state": {
+       "description": "Scale",
+       "layout": "IPY_MODEL_e305226a73c74f958ffe7d13ea6c67f9",
+       "style": "IPY_MODEL_cf789affe8a348ff9b2f5634ae20a329"
+      }
+     },
+     "31c7164fc63141378888246dd152f9c3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "3209b8b55e3846b39813c89bfddfb56e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_cff9c375be0b4606bea265e723183c9b",
+       "max": 1,
+       "style": "IPY_MODEL_b8752a39541c4eeaacd65b784c68a5be",
+       "value": 1
+      }
+     },
+     "33984c4cc18648a5b0958576e913624c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "min_width": "150px"
+      }
+     },
+     "34777533b1cb4a9aaee28bd65e4e42d6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonModel",
+      "state": {
+       "description": "Scale",
+       "layout": "IPY_MODEL_4559adb075b94c34b0bf90a7dca3b2b3",
+       "style": "IPY_MODEL_352e76371858435b844fec944cb49b2c"
+      }
+     },
+     "352e76371858435b844fec944cb49b2c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonStyleModel",
+      "state": {}
+     },
+     "35c345b8fadd4826893daf5bfe76676a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "35d2f261e8634d66a43f8f2a11a3a0a2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "36181a4aba82410d9abbbc9e56a58ff9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "3692be9bd24d4ef7b864f1a093374f34": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "36e6dd6664ed4b90ba8d9566ad40e420": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_414516725c6149d98bd1ce90219018ac",
+       "style": "IPY_MODEL_ab0c2ead1ae4446fbd84b3a71062276a",
+       "value": "<p><b>Dashboard: </b><a href=\"/user/rsignell-usgs-h-ke-water-levels-6pu2oezq/proxy/8787/status\" target=\"_blank\">/user/rsignell-usgs-h-ke-water-levels-6pu2oezq/proxy/8787/status</a></p>\n"
+      }
+     },
+     "38e6d65a68af436eb8fcb39c2a939825": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "399d01417a014376ba1e5cc4d57f4879": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "39ff4c94852c4928a3ba4083eaf69303": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "3ca434c698bb4a888a54af6427e3a4c7": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "width": "150px"
+      }
+     },
+     "3d41d8a0e869454ca3c1df8d2858a5db": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "3e2736a14b9d4f90b71b65e2716696fb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "VBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_f2c18f48ecda442a8896dc53e19daf2f",
+        "IPY_MODEL_ab6cf742787a412fa8cf2154c2d19be9",
+        "IPY_MODEL_8ed158d92e854653a248270cc7adfee4"
+       ],
+       "layout": "IPY_MODEL_e9bcf13bf649408a9e4ec1c0c7c752ca"
+      }
+     },
+     "3ef98efc567c4ef5bf543c0e3e9059ce": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_5f15a5de639048b6b397447887c2a804",
+        "IPY_MODEL_34777533b1cb4a9aaee28bd65e4e42d6"
+       ],
+       "layout": "IPY_MODEL_5c8bf1ac32f64a39b89fdc2569d399ba"
+      }
+     },
+     "3f989af4eedc4d0380f30addccba731a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_12f2b49508b1442e9949f40d582330db",
+       "style": "IPY_MODEL_b933d5681e6d451698d17da151977ffb",
+       "value": "\n<div>\n  <style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n  </style>\n  <table style=\"text-align: right;\">\n    <tr> <th>Workers</th> <td>30</td></tr>\n    <tr> <th>Cores</th> <td>60</td></tr>\n    <tr> <th>Memory</th> <td>210.00 GB</td></tr>\n  </table>\n</div>\n"
+      }
+     },
+     "408ab12f838541a186b00c4670fb6cfd": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "VBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_9e98f8164bb84bc8bf158cf2953c3527",
+        "IPY_MODEL_fabd653922be4de6bc16dbf269a441fd",
+        "IPY_MODEL_36e6dd6664ed4b90ba8d9566ad40e420"
+       ],
+       "layout": "IPY_MODEL_190f03aa85f84e46bdb44e1a12cdf55e"
+      }
+     },
+     "40f3dfc7b06b49a886898c48658878ce": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "4107a7bcf8804ea8a4ed7d232ecdc18c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "min_width": "500px"
+      }
+     },
+     "414516725c6149d98bd1ce90219018ac": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "41b6c23d581b4723881ea724644923a3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_6406a35bf5f0409fa818788cd2337c30",
+       "style": "IPY_MODEL_15523fb1e0374bc39a3c50390d11f35c",
+       "value": "<p><b>Dashboard: </b><a href=\"/user/rsignell-usgs-h-ke-water-levels-urb2n6zi/proxy/8787/status\" target=\"_blank\">/user/rsignell-usgs-h-ke-water-levels-urb2n6zi/proxy/8787/status</a></p>\n"
+      }
+     },
+     "41b97a4ad5354fa09f20dd171d9efce8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "42b6cf7263374878ad008f88edbf7b90": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_6196503fed59480ea4f3c2e81cf698ff",
+       "style": "IPY_MODEL_39ff4c94852c4928a3ba4083eaf69303",
+       "value": "<div style=\"padding: 0px 10px 0px 10px; text-align:left; word-wrap: break-word;\">zarr</div>"
+      }
+     },
+     "42f15621223a4cfa95b06fc9a76e5aea": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_7d6f8359a06146048462ad21fad635b6",
+        "IPY_MODEL_c54a52980eb84b518358e1eebe03e1a8"
+       ],
+       "layout": "IPY_MODEL_17ab0b12d9d447c1b717ebe23db3a957"
+      }
+     },
+     "43a51302bb544fa5a186f9ddaa7efb3a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_cfbbea2ebc5a412885516a8e941c4409",
+        "IPY_MODEL_23bb3d9707fa4c8a93ddf58993391234",
+        "IPY_MODEL_9fb90b517a0548dcaabc051640685250"
+       ],
+       "layout": "IPY_MODEL_7c4b6d9c3539421dbe66e0ba2a6678c3"
+      }
+     },
+     "4472d213444a4d75b22fe6151e3f0128": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "IntTextModel",
+      "state": {
+       "description": "Workers",
+       "layout": "IPY_MODEL_2316459c1dcb4a2f851b30f4ae87e418",
+       "step": 1,
+       "style": "IPY_MODEL_84f46d1f8d444cec8e8ee55b07f4049b"
+      }
+     },
+     "447f126474da47b08cd3ca26115c2644": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonModel",
+      "state": {
+       "description": "Adapt",
+       "layout": "IPY_MODEL_c67f4247184e4514bf974e14df8ae7a9",
+       "style": "IPY_MODEL_1b0bd764f1974f2ca5bb310fe9208708"
+      }
+     },
+     "44abbec0d61c4708889b02967ede647b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_f289244e80a54bcf90624e4ee5f7e717",
+        "IPY_MODEL_07b39ec7f9984d4d975a83e143dc6172",
+        "IPY_MODEL_6db98018878a4285a7315c054e183a88"
+       ],
+       "layout": "IPY_MODEL_ab75b5bfc30b4b7dbff98bd6a1a55b26"
+      }
+     },
+     "4559adb075b94c34b0bf90a7dca3b2b3": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "width": "150px"
+      }
+     },
+     "45658eda13a14b1d86467a7a72fd3677": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "45f4c5c9c98f449f9d089fc349e27214": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "46244b84c4fa410b957ba71e0a34cb8a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "46946954376142f8b0dbc743707738e1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "4782533256cc42c3903e6a67f568e977": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_a3167a15ebd3451689ac0968c255ebae",
+       "style": "IPY_MODEL_399d01417a014376ba1e5cc4d57f4879",
+       "value": "<div style=\"padding: 0px 10px 0px 10px; text-align:left; word-wrap: break-word;\">zarr</div>"
+      }
+     },
+     "49044385caa149e589080f0e27314523": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "4acf4a412c5c4bb6854ea71b46fdee2d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "min_width": "150px"
+      }
+     },
+     "4e4e7214733243c2a46c79973b81ae70": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "4f1f297a1c524a489d284d1f5ebf9f18": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "4f69a4c8c1984c66ae14dfd9e7d65601": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "513117387e1d45d7ba718f8b54f5f845": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "51815c4353524c2a8b8beaac913c84b4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_f5c4287c7e224928a83cb404f12bcf2e",
+        "IPY_MODEL_3209b8b55e3846b39813c89bfddfb56e",
+        "IPY_MODEL_42b6cf7263374878ad008f88edbf7b90"
+       ],
+       "layout": "IPY_MODEL_970ee1718f7a4435a323fc7b02b0a8b2"
+      }
+     },
+     "520689ee6b1a4768abb41e6a40bfb9d1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "5231cbb4e0eb4f8285017a59a7bb86dd": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "VBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_7a444acef8cb46a8b115cfbad95294c1",
+        "IPY_MODEL_ac58f19a1952485bb57f7a6df5b1e66f",
+        "IPY_MODEL_41b6c23d581b4723881ea724644923a3"
+       ],
+       "layout": "IPY_MODEL_77c831945b4540a7b1cd68f75395d4a8"
+      }
+     },
+     "5257e06ca43a46a888ad0b8713526b59": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5274045bd9b8441fb087716ada153167": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonModel",
+      "state": {
+       "description": "Scale",
+       "layout": "IPY_MODEL_d0c78f023653424da0254f039522680d",
+       "style": "IPY_MODEL_02bcdb22428b4e29a02d2f501fa59ad1"
+      }
+     },
+     "52fd1f40800c445d8d550d001234697f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "IntTextModel",
+      "state": {
+       "description": "Minimum",
+       "layout": "IPY_MODEL_ab4827e391e94ca9858c12c5388a7791",
+       "step": 1,
+       "style": "IPY_MODEL_daedf7e1c46d41998157783f6135417b"
+      }
+     },
+     "5580dd8e2c1e45b1815978cba5933f8c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "55a94b77dcaa4559a82c6d9d63d5fc9b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "AccordionModel",
+      "state": {
+       "_titles": {
+        "0": "Manual Scaling",
+        "1": "Adaptive Scaling"
+       },
+       "children": [
+        "IPY_MODEL_892317247f9a4f4ca2ccdb92ce49106f",
+        "IPY_MODEL_44abbec0d61c4708889b02967ede647b"
+       ],
+       "layout": "IPY_MODEL_9f41cffb3aea4c9196c416e547897849",
+       "selected_index": null
+      }
+     },
+     "55e8e8ae71f041d1a3eaa0cf6b848642": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_ae2e9fdc14e24ca6b3162bf14d239de2",
+       "style": "IPY_MODEL_061e3b19ad0944bb98c6b44bd10a989c",
+       "value": "<div style=\"padding: 0px 10px 0px 10px; text-align:left; word-wrap: break-word;\">nanmax</div>"
+      }
+     },
+     "57c14ee7bbc146968b56a663d244f14a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "IntTextModel",
+      "state": {
+       "description": "Minimum",
+       "layout": "IPY_MODEL_e305226a73c74f958ffe7d13ea6c67f9",
+       "step": 1,
+       "style": "IPY_MODEL_9c7f24f656d94aa2ae05a9291a26dc05"
+      }
+     },
+     "593b31b05bdf41629cfcd8b01d343fe3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "5a946da01d0546e0b64e1b4b662c32e4": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5aa9e1262d7d43f182ed8e46392dbdee": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "min_width": "500px"
+      }
+     },
+     "5ab4628605b44c2cb2f28f07277c85ba": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "5ab52130ef9c43a4bf0d252df0230efd": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5b148f98c7da47678f5e38de89b5c215": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_6ac5bb449ff240958a595f2945a0116f",
+       "max": 1,
+       "style": "IPY_MODEL_9c95f8d4855e4dca878a079683fff1bf",
+       "value": 1
+      }
+     },
+     "5b31bbf7e7a242b7ab389aad391f887b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "width": "150px"
+      }
+     },
+     "5b6ec018f5b4431bb72b74396104d5db": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "VBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_7bacbb75886541f6b9082472f3befaf7",
+        "IPY_MODEL_14fdab47ae8c404c9731a2d015bf7fee",
+        "IPY_MODEL_bfbe2870f81246989cd15cbeb5ccde92",
+        "IPY_MODEL_965208081fe14ed69f620152806251b1"
+       ],
+       "layout": "IPY_MODEL_940eb1f376b44d81b88e7dad912a4c9e"
+      }
+     },
+     "5bcc30cddc324a709c7786b66cb2b84f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5c8bf1ac32f64a39b89fdc2569d399ba": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5eed5120c01345d1aae564b30fa59337": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_52fd1f40800c445d8d550d001234697f",
+        "IPY_MODEL_d88b6991ecbc48849e034219e25ecec1",
+        "IPY_MODEL_e74b252dede544bf97f00512cf80b66d"
+       ],
+       "layout": "IPY_MODEL_40f3dfc7b06b49a886898c48658878ce"
+      }
+     },
+     "5f15a5de639048b6b397447887c2a804": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "IntTextModel",
+      "state": {
+       "description": "Workers",
+       "layout": "IPY_MODEL_4559adb075b94c34b0bf90a7dca3b2b3",
+       "step": 1,
+       "style": "IPY_MODEL_15e58519bb39487596d838ec8c190681"
+      }
+     },
+     "5f3270efafd84a80a94eb7a3e834faa4": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5fed2b245bec4760b5032e5862bd90a2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "6090404403a64908b5a555c061e72a50": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "AccordionModel",
+      "state": {
+       "_titles": {
+        "0": "Manual Scaling",
+        "1": "Adaptive Scaling"
+       },
+       "children": [
+        "IPY_MODEL_c76740c9c6344e79b056f234945438fb",
+        "IPY_MODEL_92e663fba9974b3e8132742721ccfdc4"
+       ],
+       "layout": "IPY_MODEL_5aa9e1262d7d43f182ed8e46392dbdee",
+       "selected_index": null
+      }
+     },
+     "6093bd652b3f4db5a386268e9511e965": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "AccordionModel",
+      "state": {
+       "_titles": {
+        "0": "Manual Scaling",
+        "1": "Adaptive Scaling"
+       },
+       "children": [
+        "IPY_MODEL_e42c1e4259c046f6b04cef3dc9f59e76",
+        "IPY_MODEL_922bac5c092042de8349ef53c41fc579"
+       ],
+       "layout": "IPY_MODEL_bc10e5f522a54a60a17aae9d274560c6",
+       "selected_index": null
+      }
+     },
+     "60bc30aaef0d4010b78b2b17d434ea90": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "IntTextModel",
+      "state": {
+       "description": "Minimum",
+       "layout": "IPY_MODEL_d0c78f023653424da0254f039522680d",
+       "step": 1,
+       "style": "IPY_MODEL_36181a4aba82410d9abbbc9e56a58ff9"
+      }
+     },
+     "6188678c53014cd3a42c101284e15f2b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "6196503fed59480ea4f3c2e81cf698ff": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "61e851f193c14db899080397c3637c40": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonStyleModel",
+      "state": {}
+     },
+     "632fa9a0549d4adeb638a560cee28c65": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "6406a35bf5f0409fa818788cd2337c30": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "64f3b7fcd1d649a496fcd7ed6da7c050": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "IntTextModel",
+      "state": {
+       "description": "Maximum",
+       "layout": "IPY_MODEL_2316459c1dcb4a2f851b30f4ae87e418",
+       "step": 1,
+       "style": "IPY_MODEL_bfde6c81284c43e1ae4005e9de4e80c2"
+      }
+     },
+     "65a1ab18d6c342ad930dc491e295e12c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_a899560edcdd40afb8fa5c3dada60a6f",
+       "style": "IPY_MODEL_0cf8bb6e1c1a4bd2bb9f4d40e537dad4",
+       "value": "\n<div>\n  <style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n  </style>\n  <table style=\"text-align: right;\">\n    <tr> <th>Workers</th> <td>30</td></tr>\n    <tr> <th>Cores</th> <td>60</td></tr>\n    <tr> <th>Memory</th> <td>210.00 GB</td></tr>\n  </table>\n</div>\n"
+      }
+     },
+     "6710bf2c24a642fe9f36fd0e8154b342": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "67b50bf2dfa243be9259fb2bd3630bd1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "VBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_c9a88b5601ea479e9d44183b90815b73",
+        "IPY_MODEL_5b6ec018f5b4431bb72b74396104d5db"
+       ],
+       "layout": "IPY_MODEL_d299dfb8bbf24365a17821105565dd02"
+      }
+     },
+     "68716ec4722247b48ff8e36b96fc483c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_6ec3957bb8ac4e04b6e6e9b0a2413cd0",
+        "IPY_MODEL_86d088b32b614cb3bdffa5e055c5a5bd"
+       ],
+       "layout": "IPY_MODEL_201df16f02724c9dba5408868470de3a"
+      }
+     },
+     "6a2667550c2a4cb482f515799355737f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_b80e29555c094ad088824526ac9b6686",
+       "style": "IPY_MODEL_e59ba99ac1e642bdb42f238501e5cd45",
+       "value": "\n<div>\n  <style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n  </style>\n  <table style=\"text-align: right;\">\n    <tr> <th>Workers</th> <td>30</td></tr>\n    <tr> <th>Cores</th> <td>60</td></tr>\n    <tr> <th>Memory</th> <td>210.00 GB</td></tr>\n  </table>\n</div>\n"
+      }
+     },
+     "6a94197658394c088251afe7ea27871c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonStyleModel",
+      "state": {}
+     },
+     "6ac5bb449ff240958a595f2945a0116f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "6b113ce93f91483bab0f5195671c2233": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "min_width": "500px"
+      }
+     },
+     "6b3abb3e1d9f4a9685960ac30e86037b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "6d01a84902be460aa27a72b0da24383a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "6db98018878a4285a7315c054e183a88": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonModel",
+      "state": {
+       "description": "Adapt",
+       "layout": "IPY_MODEL_3ca434c698bb4a888a54af6427e3a4c7",
+       "style": "IPY_MODEL_f2cc50fbdc8040aca0eb433c183b6485"
+      }
+     },
+     "6dc7f1d0bad5410fa0dc13eab0a65e40": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "min_width": "150px"
+      }
+     },
+     "6ec3957bb8ac4e04b6e6e9b0a2413cd0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "IntTextModel",
+      "state": {
+       "description": "Workers",
+       "layout": "IPY_MODEL_5b31bbf7e7a242b7ab389aad391f887b",
+       "step": 1,
+       "style": "IPY_MODEL_8c806762c78e4e8296c6c1762fa86d18"
+      }
+     },
+     "72a8a02431f9451fa5b54fd29c858008": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "IntTextModel",
+      "state": {
+       "description": "Workers",
+       "layout": "IPY_MODEL_3ca434c698bb4a888a54af6427e3a4c7",
+       "step": 1,
+       "style": "IPY_MODEL_a26f9d2c6b7b47c8b571526f1408789a"
+      }
+     },
+     "72dd87a1b30c4e358388d07a5318686b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonModel",
+      "state": {
+       "description": "Scale",
+       "layout": "IPY_MODEL_c67f4247184e4514bf974e14df8ae7a9",
+       "style": "IPY_MODEL_61e851f193c14db899080397c3637c40"
+      }
+     },
+     "732f93ed8a0544e89ea131b882079f09": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "73489cc81b674c099c183542cc4cde8d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_5ab52130ef9c43a4bf0d252df0230efd",
+       "style": "IPY_MODEL_b6ed13ff28a0480395a3c26634e91cac",
+       "value": "<div style=\"padding: 0px 10px 0px 10px; text-align: right\">1560 / 1560</div>"
+      }
+     },
+     "74b82189e5454a4a995f2f866c3fc2c0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "7510953f3a1c4d96a209a2e647575c59": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "754e0afa579c44a3abb32b1eba31736a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_21ff3afbbcbe4f9a92819add7599d64b",
+       "style": "IPY_MODEL_f0370c91d5b942a598d761e971f845ed",
+       "value": "<h2>KubeCluster</h2>"
+      }
+     },
+     "7560e5c8cc2a4d33bbe7fc5dced09845": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "77694b68b009421b95468e726e6c00fc": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "77c831945b4540a7b1cd68f75395d4a8": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "78f91f7bec794354a5e7971cda40b1ab": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "IntTextModel",
+      "state": {
+       "description": "Maximum",
+       "layout": "IPY_MODEL_c67f4247184e4514bf974e14df8ae7a9",
+       "step": 1,
+       "style": "IPY_MODEL_3d41d8a0e869454ca3c1df8d2858a5db"
+      }
+     },
+     "7975e2d5636a4c8ba73b733318d1e977": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "IntTextModel",
+      "state": {
+       "description": "Workers",
+       "layout": "IPY_MODEL_d0c78f023653424da0254f039522680d",
+       "step": 1,
+       "style": "IPY_MODEL_e9b592d13cd143d3b7746a48cd53d202"
+      }
+     },
+     "7a25ff623e6948bcb52a76c4a375645b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7a444acef8cb46a8b115cfbad95294c1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_8c932b8b1c0b4e92adbb4e96ad7d4cc2",
+       "style": "IPY_MODEL_38e6d65a68af436eb8fcb39c2a939825",
+       "value": "<h2>KubeCluster</h2>"
+      }
+     },
+     "7a57b35656b04ab79b504c291000cc88": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7acb0730a5f84604b97333000034a1af": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "7b7214679e364be2a633f71469a65f61": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7bacbb75886541f6b9082472f3befaf7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_d00f87cb80eb462aa6bd5190ccaf3cda",
+        "IPY_MODEL_8af817497b5a4025835a6be94e5e4dbe",
+        "IPY_MODEL_4782533256cc42c3903e6a67f568e977"
+       ],
+       "layout": "IPY_MODEL_e6479441b83340aea9a4a5db29af0aaf"
+      }
+     },
+     "7c4b6d9c3539421dbe66e0ba2a6678c3": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7c7705497a2a444bb0ab147da79f9922": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "7d6f8359a06146048462ad21fad635b6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_17a5a7909be44a47ade2682ea53a7d22",
+       "style": "IPY_MODEL_908d1203aa6d4e469ae4daa9f1c9f02f",
+       "value": "\n<div>\n  <style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n  </style>\n  <table style=\"text-align: right;\">\n    <tr> <th>Workers</th> <td>30</td></tr>\n    <tr> <th>Cores</th> <td>60</td></tr>\n    <tr> <th>Memory</th> <td>210.00 GB</td></tr>\n  </table>\n</div>\n"
+      }
+     },
+     "7e622c5f8a8944838e5be76c91c52563": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "7e8f27ed66e24f45abcb2462a9cf0a7e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_f9282aa1eb984b008506c3e524a38842",
+       "style": "IPY_MODEL_46946954376142f8b0dbc743707738e1",
+       "value": "<h2>KubeCluster</h2>"
+      }
+     },
+     "7ed07c4f269348ce877d7413ec1ba53e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7f6ea6483f0e42aa9bde34359d1a383d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "AccordionModel",
+      "state": {
+       "_titles": {
+        "0": "Manual Scaling",
+        "1": "Adaptive Scaling"
+       },
+       "children": [
+        "IPY_MODEL_68716ec4722247b48ff8e36b96fc483c",
+        "IPY_MODEL_43a51302bb544fa5a186f9ddaa7efb3a"
+       ],
+       "layout": "IPY_MODEL_1a6617309a5f41f697b30c0126ab903a",
+       "selected_index": null
+      }
+     },
+     "7ff152f5dd634bbfbc4a7c37a728f29d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "8164317914ae483da528bbb0b9498798": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "82067ceccd114f81b85d6b78848fa45a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "83268aac72194c14a848e95024d2135c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "84f2a27cc465487c9ba91cc0ccc76249": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonModel",
+      "state": {
+       "description": "Scale",
+       "layout": "IPY_MODEL_2316459c1dcb4a2f851b30f4ae87e418",
+       "style": "IPY_MODEL_d1607521bea24222bc44a94ad5f22bc5"
+      }
+     },
+     "84f46d1f8d444cec8e8ee55b07f4049b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "86cda597474343f990730a66d71dce98": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "86d088b32b614cb3bdffa5e055c5a5bd": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonModel",
+      "state": {
+       "description": "Scale",
+       "layout": "IPY_MODEL_5b31bbf7e7a242b7ab389aad391f887b",
+       "style": "IPY_MODEL_a1fbb952ab7f464cb08cc83df445cb50"
+      }
+     },
+     "892317247f9a4f4ca2ccdb92ce49106f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_72a8a02431f9451fa5b54fd29c858008",
+        "IPY_MODEL_c395b014fa91428c8ff70b733bad0446"
+       ],
+       "layout": "IPY_MODEL_04d2019b2c424e49ad84be438b76ec89"
+      }
+     },
+     "8aacd84cd3d643049afa436d7e907654": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8af817497b5a4025835a6be94e5e4dbe": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_f450a4fb334a4e31a7957f6ef935d62a",
+       "max": 1,
+       "style": "IPY_MODEL_45f4c5c9c98f449f9d089fc349e27214",
+       "value": 1
+      }
+     },
+     "8bf63849255d43598683d8e08df9b610": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8c6015c3d7604e698318912f87530bab": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8c806762c78e4e8296c6c1762fa86d18": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "8c932b8b1c0b4e92adbb4e96ad7d4cc2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8ced8f9e9a3a4b05a35740967873824b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8ed158d92e854653a248270cc7adfee4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_cff6b1098dc64e3087f89fa07f4ddf6c",
+       "style": "IPY_MODEL_fceb299bd8cb4252a54965cdf932b5d3",
+       "value": "<p><b>Dashboard: </b><a href=\"/user/rsignell-usgs-h-ke-water-levels-6pu2oezq/proxy/8787/status\" target=\"_blank\">/user/rsignell-usgs-h-ke-water-levels-6pu2oezq/proxy/8787/status</a></p>\n"
+      }
+     },
+     "8f48097421974876a61378a1dd6911a9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_e46c260b137e4a8bad8241f8ea44a32a",
+       "style": "IPY_MODEL_5580dd8e2c1e45b1815978cba5933f8c",
+       "value": "<h2>KubeCluster</h2>"
+      }
+     },
+     "908acaee80b340f7ab101498e331a686": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "IntTextModel",
+      "state": {
+       "description": "Minimum",
+       "layout": "IPY_MODEL_c67f4247184e4514bf974e14df8ae7a9",
+       "step": 1,
+       "style": "IPY_MODEL_a0a4d782f93f4e7dbc86ce5b7160650f"
+      }
+     },
+     "908d1203aa6d4e469ae4daa9f1c9f02f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "922bac5c092042de8349ef53c41fc579": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_1ea66a93d68e4731ad555f47a3cc8d8c",
+        "IPY_MODEL_64f3b7fcd1d649a496fcd7ed6da7c050",
+        "IPY_MODEL_c5031e53e72f41dc948c47f51ba14c78"
+       ],
+       "layout": "IPY_MODEL_1afdd05f0cbc4adabfe91d337e2ce3a4"
+      }
+     },
+     "92e663fba9974b3e8132742721ccfdc4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_908acaee80b340f7ab101498e331a686",
+        "IPY_MODEL_78f91f7bec794354a5e7971cda40b1ab",
+        "IPY_MODEL_447f126474da47b08cd3ca26115c2644"
+       ],
+       "layout": "IPY_MODEL_0c3940b2272948a1b9dd0b7ce7901cf3"
+      }
+     },
+     "940eb1f376b44d81b88e7dad912a4c9e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "950787a0bc8e4a22a5da0e30d808d266": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_6188678c53014cd3a42c101284e15f2b",
+       "style": "IPY_MODEL_41b97a4ad5354fa09f20dd171d9efce8",
+       "value": "<div style=\"padding: 0px 10px 5px 10px\"><b>Finished:</b> 37.0s</div>"
+      }
+     },
+     "959d68a330a54deb9d968b825090ee8a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "965208081fe14ed69f620152806251b1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_f1f974bd02ca485da5f00855978d99ca",
+        "IPY_MODEL_2587b46f1029494593df370baf3af340",
+        "IPY_MODEL_16786dadcea8412195bede48e8d110d4"
+       ],
+       "layout": "IPY_MODEL_82067ceccd114f81b85d6b78848fa45a"
+      }
+     },
+     "970ee1718f7a4435a323fc7b02b0a8b2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "9808942a2590498abd85f56a1b39309e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_b2e59680361a4cf4b338543bbf2d6d03",
+        "IPY_MODEL_b6a023d521014514adc6d91767cae15d"
+       ],
+       "layout": "IPY_MODEL_0b019f9ea9864ec898ba7f25f6d2c246"
+      }
+     },
+     "9870b2d3347c44e3b117f5a40d66e8e3": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "99af29a9becd4dc3afbf800522d97026": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "99c3b0fc5ab040c99820bdf2a971dbfe": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_fb569e3e2e3a431a8d2e36ff98d9b5c9",
+        "IPY_MODEL_311f02a5b5e24d3d8509c82e28be4563"
+       ],
+       "layout": "IPY_MODEL_ab3429d93e734ca48019797736ce54e9"
+      }
+     },
+     "99ee9fb22c5046039e85d4f6344b1a87": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "9c7f24f656d94aa2ae05a9291a26dc05": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "9c95f8d4855e4dca878a079683fff1bf": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "9cf762cbf5e846bba0f9c018e6971471": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "9e98f8164bb84bc8bf158cf2953c3527": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_b1b2eba26b7048158ec8fffaf7fd3ee7",
+       "style": "IPY_MODEL_da446c552a01404c9e41a3a8903e0861",
+       "value": "<h2>KubeCluster</h2>"
+      }
+     },
+     "9f41cffb3aea4c9196c416e547897849": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "min_width": "500px"
+      }
+     },
+     "9f9365f1a78548de9e8ef23ec2c31c5f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "9fb90b517a0548dcaabc051640685250": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonModel",
+      "state": {
+       "description": "Adapt",
+       "layout": "IPY_MODEL_5b31bbf7e7a242b7ab389aad391f887b",
+       "style": "IPY_MODEL_bfae996fbdee451b984631fedd685108"
+      }
+     },
+     "a0a4d782f93f4e7dbc86ce5b7160650f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a1a2b581e4e34b7f91cc7e213876873d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_632fa9a0549d4adeb638a560cee28c65",
+       "style": "IPY_MODEL_deff1e585d764049bc430ee5b29507ef",
+       "value": "<h2>KubeCluster</h2>"
+      }
+     },
+     "a1fbb952ab7f464cb08cc83df445cb50": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonStyleModel",
+      "state": {}
+     },
+     "a26f9d2c6b7b47c8b571526f1408789a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a3167a15ebd3451689ac0968c255ebae": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a33c1d9bf47741e6877f6a09923ed845": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_f2942b13497a4940b9ae59f9573dd8de",
+       "style": "IPY_MODEL_4e4e7214733243c2a46c79973b81ae70",
+       "value": "<div style=\"padding: 0px 10px 0px 10px; text-align:left; word-wrap: break-word;\">nanmax-partial</div>"
+      }
+     },
+     "a513c7ba17464c53ad8d52c00f91703e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_7a57b35656b04ab79b504c291000cc88",
+       "style": "IPY_MODEL_7560e5c8cc2a4d33bbe7fc5dced09845",
+       "value": "<p><b>Dashboard: </b><a href=\"/user/rsignell-usgs-h-ke-water-levels-6pu2oezq/proxy/8787/status\" target=\"_blank\">/user/rsignell-usgs-h-ke-water-levels-6pu2oezq/proxy/8787/status</a></p>\n"
+      }
+     },
+     "a74db149a62140d8bdd0b3ffa3d6b9de": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a7900f6a21354cdaaa9dab9ecb0f67bb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonModel",
+      "state": {
+       "description": "Adapt",
+       "layout": "IPY_MODEL_4559adb075b94c34b0bf90a7dca3b2b3",
+       "style": "IPY_MODEL_db0b02dc1e354ed7a9c15d994bc9bfac"
+      }
+     },
+     "a899560edcdd40afb8fa5c3dada60a6f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "min_width": "150px"
+      }
+     },
+     "ab0c2ead1ae4446fbd84b3a71062276a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "ab3429d93e734ca48019797736ce54e9": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ab4827e391e94ca9858c12c5388a7791": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "width": "150px"
+      }
+     },
+     "ab6cf742787a412fa8cf2154c2d19be9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_b6dca32be5734d1a96586cc88b472a39",
+        "IPY_MODEL_b982879546f447caba5ee909881cf1b3"
+       ],
+       "layout": "IPY_MODEL_8ced8f9e9a3a4b05a35740967873824b"
+      }
+     },
+     "ab75b5bfc30b4b7dbff98bd6a1a55b26": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ac58f19a1952485bb57f7a6df5b1e66f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_65a1ab18d6c342ad930dc491e295e12c",
+        "IPY_MODEL_c9cc5588374c423b9979c39696a6021d"
+       ],
+       "layout": "IPY_MODEL_b8c6e108f80b4bf48bf73e873880033a"
+      }
+     },
+     "ad76f890ed824bac9d234496e42161d7": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ae2e9fdc14e24ca6b3162bf14d239de2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ae3338f3970a4c7bb0b7ac615a5238ae": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "aea046c671ce4a82b09b0b0b00b0aa69": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_3f989af4eedc4d0380f30addccba731a",
+        "IPY_MODEL_7f6ea6483f0e42aa9bde34359d1a383d"
+       ],
+       "layout": "IPY_MODEL_8bf63849255d43598683d8e08df9b610"
+      }
+     },
+     "aeaee65127214100b10430a0b23f51b7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_7ed07c4f269348ce877d7413ec1ba53e",
+       "style": "IPY_MODEL_e6796f86b99c4f9f91ac41e8a0870ce9",
+       "value": "<p><b>Dashboard: </b><a href=\"/user/rsignell-usgs-h-ke-water-levels-yl0yiypg/proxy/8787/status\" target=\"_blank\">/user/rsignell-usgs-h-ke-water-levels-yl0yiypg/proxy/8787/status</a></p>\n"
+      }
+     },
+     "af1d40c2689f4c7b85fa15dd65f610b6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_49044385caa149e589080f0e27314523",
+       "style": "IPY_MODEL_7e622c5f8a8944838e5be76c91c52563",
+       "value": "<h2>KubeCluster</h2>"
+      }
+     },
+     "afc1315077c04916bee32e2c2646d5d4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_b327237ab472404e9b3677ddd0c4325d",
+       "max": 1,
+       "style": "IPY_MODEL_520689ee6b1a4768abb41e6a40bfb9d1",
+       "value": 1
+      }
+     },
+     "b170535b13274007812b21a510e4f762": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "IntTextModel",
+      "state": {
+       "description": "Maximum",
+       "layout": "IPY_MODEL_d0c78f023653424da0254f039522680d",
+       "step": 1,
+       "style": "IPY_MODEL_df1b736472224a51a71b234c3f672add"
+      }
+     },
+     "b1b2eba26b7048158ec8fffaf7fd3ee7": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b1e49a0631b449ccb5e3e28e78e51f79": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "IntTextModel",
+      "state": {
+       "description": "Workers",
+       "layout": "IPY_MODEL_ab4827e391e94ca9858c12c5388a7791",
+       "step": 1,
+       "style": "IPY_MODEL_efca15215c994290b7a6b07c63ad245e"
+      }
+     },
+     "b2a579754a504fde952923508b4d0a23": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "IntTextModel",
+      "state": {
+       "description": "Maximum",
+       "layout": "IPY_MODEL_e305226a73c74f958ffe7d13ea6c67f9",
+       "step": 1,
+       "style": "IPY_MODEL_f002249a77de469eb6c2a24f31ed29ae"
+      }
+     },
+     "b2e59680361a4cf4b338543bbf2d6d03": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_0a1f3eab748f479c9acba6cb99eebe32",
+       "style": "IPY_MODEL_35d2f261e8634d66a43f8f2a11a3a0a2",
+       "value": "\n<div>\n  <style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n  </style>\n  <table style=\"text-align: right;\">\n    <tr> <th>Workers</th> <td>30</td></tr>\n    <tr> <th>Cores</th> <td>60</td></tr>\n    <tr> <th>Memory</th> <td>210.00 GB</td></tr>\n  </table>\n</div>\n"
+      }
+     },
+     "b30634abf2ee46ca88176a7578b31da7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "VBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_950787a0bc8e4a22a5da0e30d808d266",
+        "IPY_MODEL_2afdd253f91d4f2699d8e8304c08d6cd"
+       ],
+       "layout": "IPY_MODEL_d6f2c5ec10a2435d97381cc22f8cb963"
+      }
+     },
+     "b327237ab472404e9b3677ddd0c4325d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b6a023d521014514adc6d91767cae15d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "AccordionModel",
+      "state": {
+       "_titles": {
+        "0": "Manual Scaling",
+        "1": "Adaptive Scaling"
+       },
+       "children": [
+        "IPY_MODEL_99c3b0fc5ab040c99820bdf2a971dbfe",
+        "IPY_MODEL_1996e83e6d904ef7a2c1bf43d38d42c3"
+       ],
+       "layout": "IPY_MODEL_05168f616c1a488bac2900443e8791fd",
+       "selected_index": null
+      }
+     },
+     "b6dca32be5734d1a96586cc88b472a39": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_6dc7f1d0bad5410fa0dc13eab0a65e40",
+       "style": "IPY_MODEL_35c345b8fadd4826893daf5bfe76676a",
+       "value": "\n<div>\n  <style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n  </style>\n  <table style=\"text-align: right;\">\n    <tr> <th>Workers</th> <td>30</td></tr>\n    <tr> <th>Cores</th> <td>60</td></tr>\n    <tr> <th>Memory</th> <td>210.00 GB</td></tr>\n  </table>\n</div>\n"
+      }
+     },
+     "b6ed13ff28a0480395a3c26634e91cac": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "b72b447e0e1a4d9584d6d5d200e31452": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_b1e49a0631b449ccb5e3e28e78e51f79",
+        "IPY_MODEL_f3a92cdb4d6749169038bb6226c78a7c"
+       ],
+       "layout": "IPY_MODEL_7510953f3a1c4d96a209a2e647575c59"
+      }
+     },
+     "b750608fdd904e73848947e0aa0bae1e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_8aacd84cd3d643049afa436d7e907654",
+       "style": "IPY_MODEL_7ff152f5dd634bbfbc4a7c37a728f29d",
+       "value": "<div style=\"padding: 0px 10px 0px 10px; text-align: right\">1560 / 1560</div>"
+      }
+     },
+     "b7f365507fe741c5880d1eea7befdc9c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonStyleModel",
+      "state": {}
+     },
+     "b80e29555c094ad088824526ac9b6686": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "min_width": "150px"
+      }
+     },
+     "b8752a39541c4eeaacd65b784c68a5be": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ProgressStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "b8c6e108f80b4bf48bf73e873880033a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b933d5681e6d451698d17da151977ffb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "b982879546f447caba5ee909881cf1b3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "AccordionModel",
+      "state": {
+       "_titles": {
+        "0": "Manual Scaling",
+        "1": "Adaptive Scaling"
+       },
+       "children": [
+        "IPY_MODEL_b72b447e0e1a4d9584d6d5d200e31452",
+        "IPY_MODEL_5eed5120c01345d1aae564b30fa59337"
+       ],
+       "layout": "IPY_MODEL_4107a7bcf8804ea8a4ed7d232ecdc18c",
+       "selected_index": null
+      }
+     },
+     "bc10e5f522a54a60a17aae9d274560c6": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "min_width": "500px"
+      }
+     },
+     "bdfc56e2940c4c739ff1d5faeec40d7f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_1c8a8108a8074d60bcca05d85424d9ec",
+       "max": 1,
+       "style": "IPY_MODEL_17a6ed6ba13647c390a2823596970f1d",
+       "value": 1
+      }
+     },
+     "be383dd316be43b194363fdb6537fa8e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "VBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_af1d40c2689f4c7b85fa15dd65f610b6",
+        "IPY_MODEL_e415c923c3dc414aa2a17aae43a02191",
+        "IPY_MODEL_19cbd86344b74600a4361f37f842e212"
+       ],
+       "layout": "IPY_MODEL_5bcc30cddc324a709c7786b66cb2b84f"
+      }
+     },
+     "bfae996fbdee451b984631fedd685108": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonStyleModel",
+      "state": {}
+     },
+     "bfbe2870f81246989cd15cbeb5ccde92": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_73489cc81b674c099c183542cc4cde8d",
+        "IPY_MODEL_07d213ec9c774483937f447bf3dd86ae",
+        "IPY_MODEL_cfd949b4e0154e3f8ec5025d34503dd7"
+       ],
+       "layout": "IPY_MODEL_290d0f4b92f4483ca42ece3d69c9a8df"
+      }
+     },
+     "bfde6c81284c43e1ae4005e9de4e80c2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "c0cf7ff58a06494cbcff7175e9585dd0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonModel",
+      "state": {
+       "description": "Adapt",
+       "layout": "IPY_MODEL_d0c78f023653424da0254f039522680d",
+       "style": "IPY_MODEL_ddb402aea3154a8997d978f8fc2ce616"
+      }
+     },
+     "c15eb2b3ca8847d9b1af872e019583f4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_7a25ff623e6948bcb52a76c4a375645b",
+       "style": "IPY_MODEL_ff7b8038de9740508084b810f37d68bc",
+       "value": "<div style=\"padding: 0px 10px 0px 10px; text-align: right\">4680 / 4680</div>"
+      }
+     },
+     "c26b6a857a4f4a6ba3888dcfc228c03e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c3845d49e86d409fb6378855a838ab74": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonStyleModel",
+      "state": {}
+     },
+     "c395b014fa91428c8ff70b733bad0446": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonModel",
+      "state": {
+       "description": "Scale",
+       "layout": "IPY_MODEL_3ca434c698bb4a888a54af6427e3a4c7",
+       "style": "IPY_MODEL_c69b5df9542f40bd9b9bee0febdc6ef3"
+      }
+     },
+     "c5031e53e72f41dc948c47f51ba14c78": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonModel",
+      "state": {
+       "description": "Adapt",
+       "layout": "IPY_MODEL_2316459c1dcb4a2f851b30f4ae87e418",
+       "style": "IPY_MODEL_c3845d49e86d409fb6378855a838ab74"
+      }
+     },
+     "c54a52980eb84b518358e1eebe03e1a8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "AccordionModel",
+      "state": {
+       "_titles": {
+        "0": "Manual Scaling",
+        "1": "Adaptive Scaling"
+       },
+       "children": [
+        "IPY_MODEL_3ef98efc567c4ef5bf543c0e3e9059ce",
+        "IPY_MODEL_f44bd6192dea4ee18bd7b5bad3c1fa6a"
+       ],
+       "layout": "IPY_MODEL_188743e690f84d7c98d69fe1d4504c3f",
+       "selected_index": null
+      }
+     },
+     "c67f4247184e4514bf974e14df8ae7a9": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "width": "150px"
+      }
+     },
+     "c69b5df9542f40bd9b9bee0febdc6ef3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonStyleModel",
+      "state": {}
+     },
+     "c76740c9c6344e79b056f234945438fb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_077d5c2a0d3546dcaf5c52166fe1f22b",
+        "IPY_MODEL_72dd87a1b30c4e358388d07a5318686b"
+       ],
+       "layout": "IPY_MODEL_c26b6a857a4f4a6ba3888dcfc228c03e"
+      }
+     },
+     "c951822a4060472d813c7cc6ad574143": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "IntTextModel",
+      "state": {
+       "description": "Minimum",
+       "layout": "IPY_MODEL_4559adb075b94c34b0bf90a7dca3b2b3",
+       "step": 1,
+       "style": "IPY_MODEL_f084259e5f844a359a7e8cec09b7405e"
+      }
+     },
+     "c9a79aebecfe4caab349cbf4de843939": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonModel",
+      "state": {
+       "description": "Adapt",
+       "layout": "IPY_MODEL_e305226a73c74f958ffe7d13ea6c67f9",
+       "style": "IPY_MODEL_6a94197658394c088251afe7ea27871c"
+      }
+     },
+     "c9a88b5601ea479e9d44183b90815b73": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_f30283674ce845f2bc15fe4f8705fc37",
+       "style": "IPY_MODEL_20a8bb4121724332a556e3906aa1bbd7",
+       "value": "<div style=\"padding: 0px 10px 5px 10px\"><b>Finished:</b>  1min 29.5s</div>"
+      }
+     },
+     "c9cc5588374c423b9979c39696a6021d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "AccordionModel",
+      "state": {
+       "_titles": {
+        "0": "Manual Scaling",
+        "1": "Adaptive Scaling"
+       },
+       "children": [
+        "IPY_MODEL_ddccee0d1539461a8ffefd0eb0830570",
+        "IPY_MODEL_cf03a860ad994c5b882a69d0d1bfe299"
+       ],
+       "layout": "IPY_MODEL_6b113ce93f91483bab0f5195671c2233",
+       "selected_index": null
+      }
+     },
+     "ca87311e69644740b5fbb4c1d76086d0": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "cc88f89404f84fcfbf0ee2f4add73c77": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "cf03a860ad994c5b882a69d0d1bfe299": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_60bc30aaef0d4010b78b2b17d434ea90",
+        "IPY_MODEL_b170535b13274007812b21a510e4f762",
+        "IPY_MODEL_c0cf7ff58a06494cbcff7175e9585dd0"
+       ],
+       "layout": "IPY_MODEL_d8cacf43ae2a46c28058ad8ac5b48b41"
+      }
+     },
+     "cf0a449cea2046f6a33ca2007eee69de": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "FloatProgressModel",
+      "state": {
+       "bar_style": "success",
+       "layout": "IPY_MODEL_5a946da01d0546e0b64e1b4b662c32e4",
+       "max": 1,
+       "style": "IPY_MODEL_25a84c261f0b452caf25a81a088ba369",
+       "value": 1
+      }
+     },
+     "cf789affe8a348ff9b2f5634ae20a329": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonStyleModel",
+      "state": {}
+     },
+     "cfbbea2ebc5a412885516a8e941c4409": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "IntTextModel",
+      "state": {
+       "description": "Minimum",
+       "layout": "IPY_MODEL_5b31bbf7e7a242b7ab389aad391f887b",
+       "step": 1,
+       "style": "IPY_MODEL_14dc93d05a154953b0b1e03ed9c2feac"
+      }
+     },
+     "cfd949b4e0154e3f8ec5025d34503dd7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_5257e06ca43a46a888ad0b8713526b59",
+       "style": "IPY_MODEL_2334dd91646348518ceb0c8e50675c19",
+       "value": "<div style=\"padding: 0px 10px 0px 10px; text-align:left; word-wrap: break-word;\">nanmax-partial</div>"
+      }
+     },
+     "cff6b1098dc64e3087f89fa07f4ddf6c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "cff9c375be0b4606bea265e723183c9b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d00f87cb80eb462aa6bd5190ccaf3cda": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_198337771f7144b2b69c255c49ed3e2a",
+       "style": "IPY_MODEL_7c7705497a2a444bb0ab147da79f9922",
+       "value": "<div style=\"padding: 0px 10px 0px 10px; text-align: right\">4813 / 4813</div>"
+      }
+     },
+     "d0829399309a4a4fb39a441b0595777f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "d0c78f023653424da0254f039522680d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "width": "150px"
+      }
+     },
+     "d1607521bea24222bc44a94ad5f22bc5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonStyleModel",
+      "state": {}
+     },
+     "d299dfb8bbf24365a17821105565dd02": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d37fb3ecbbb14555b020111b7fb1d6e4": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d491c10e7f9c4c65bf35df80c5721fd9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "d4dbf99d38044b69a5fe6cdf35786915": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d665407811f84d80b15ee4c12148fca0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "d6f2c5ec10a2435d97381cc22f8cb963": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d88b6991ecbc48849e034219e25ecec1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "IntTextModel",
+      "state": {
+       "description": "Maximum",
+       "layout": "IPY_MODEL_ab4827e391e94ca9858c12c5388a7791",
+       "step": 1,
+       "style": "IPY_MODEL_d0829399309a4a4fb39a441b0595777f"
+      }
+     },
+     "d8cacf43ae2a46c28058ad8ac5b48b41": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d97a6d4c8db148989b3b44ff346bfad1": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d9962513f16d417d8138e25ab85da0b2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "da446c552a01404c9e41a3a8903e0861": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "daedf7e1c46d41998157783f6135417b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "db0b02dc1e354ed7a9c15d994bc9bfac": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonStyleModel",
+      "state": {}
+     },
+     "dc161608c8bc4a019de49bad6cc0cb2f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "dd25cdc4e80c4cc787928394e6118dbd": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "VBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_754e0afa579c44a3abb32b1eba31736a",
+        "IPY_MODEL_2ec6202a874e4e72a4d4f0a12ef242a0",
+        "IPY_MODEL_f1707986ffc747dda0f4997108485ec3"
+       ],
+       "layout": "IPY_MODEL_cc88f89404f84fcfbf0ee2f4add73c77"
+      }
+     },
+     "ddb402aea3154a8997d978f8fc2ce616": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonStyleModel",
+      "state": {}
+     },
+     "ddccee0d1539461a8ffefd0eb0830570": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_7975e2d5636a4c8ba73b733318d1e977",
+        "IPY_MODEL_5274045bd9b8441fb087716ada153167"
+       ],
+       "layout": "IPY_MODEL_6710bf2c24a642fe9f36fd0e8154b342"
+      }
+     },
+     "deff1e585d764049bc430ee5b29507ef": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "df1b736472224a51a71b234c3f672add": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "df5fe18cd57141db86d43128f4375603": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "e052e2f6b3fe49eb972493308248b005": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e305226a73c74f958ffe7d13ea6c67f9": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "width": "150px"
+      }
+     },
+     "e415c923c3dc414aa2a17aae43a02191": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_f7323c7f519f4836bac9bce7a3427d89",
+        "IPY_MODEL_55a94b77dcaa4559a82c6d9d63d5fc9b"
+       ],
+       "layout": "IPY_MODEL_5f3270efafd84a80a94eb7a3e834faa4"
+      }
+     },
+     "e42c1e4259c046f6b04cef3dc9f59e76": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_4472d213444a4d75b22fe6151e3f0128",
+        "IPY_MODEL_84f2a27cc465487c9ba91cc0ccc76249"
+       ],
+       "layout": "IPY_MODEL_d4dbf99d38044b69a5fe6cdf35786915"
+      }
+     },
+     "e46c260b137e4a8bad8241f8ea44a32a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e4bf2a39a6fb460baca8e2b36c4d27df": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "IntTextModel",
+      "state": {
+       "description": "Maximum",
+       "layout": "IPY_MODEL_4559adb075b94c34b0bf90a7dca3b2b3",
+       "step": 1,
+       "style": "IPY_MODEL_3692be9bd24d4ef7b864f1a093374f34"
+      }
+     },
+     "e59ba99ac1e642bdb42f238501e5cd45": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "e5fa81af4815487cb8820b002a42e2af": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "VBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_8f48097421974876a61378a1dd6911a9",
+        "IPY_MODEL_42f15621223a4cfa95b06fc9a76e5aea",
+        "IPY_MODEL_aeaee65127214100b10430a0b23f51b7"
+       ],
+       "layout": "IPY_MODEL_d97a6d4c8db148989b3b44ff346bfad1"
+      }
+     },
+     "e6479441b83340aea9a4a5db29af0aaf": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e667ec2530bb4d9bb801700b164a1ccf": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_513117387e1d45d7ba718f8b54f5f845",
+       "style": "IPY_MODEL_d665407811f84d80b15ee4c12148fca0",
+       "value": "<div style=\"padding: 0px 10px 0px 10px; text-align:left; word-wrap: break-word;\">nanmax-aggregate</div>"
+      }
+     },
+     "e6796f86b99c4f9f91ac41e8a0870ce9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "e74b252dede544bf97f00512cf80b66d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonModel",
+      "state": {
+       "description": "Adapt",
+       "layout": "IPY_MODEL_ab4827e391e94ca9858c12c5388a7791",
+       "style": "IPY_MODEL_b7f365507fe741c5880d1eea7befdc9c"
+      }
+     },
+     "e9b592d13cd143d3b7746a48cd53d202": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "e9bcf13bf649408a9e4ec1c0c7c752ca": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "eb8414bf255d4b11b91ff378ca44a033": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_b750608fdd904e73848947e0aa0bae1e",
+        "IPY_MODEL_afc1315077c04916bee32e2c2646d5d4",
+        "IPY_MODEL_a33c1d9bf47741e6877f6a09923ed845"
+       ],
+       "layout": "IPY_MODEL_ca87311e69644740b5fbb4c1d76086d0"
+      }
+     },
+     "ed51194d6f7944899d6845af16551482": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "VBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_a1a2b581e4e34b7f91cc7e213876873d",
+        "IPY_MODEL_aea046c671ce4a82b09b0b0b00b0aa69",
+        "IPY_MODEL_a513c7ba17464c53ad8d52c00f91703e"
+       ],
+       "layout": "IPY_MODEL_ad76f890ed824bac9d234496e42161d7"
+      }
+     },
+     "ed98307e48a348e2a2c20060a8c47bce": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "efca15215c994290b7a6b07c63ad245e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "f002249a77de469eb6c2a24f31ed29ae": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "f0370c91d5b942a598d761e971f845ed": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "f084259e5f844a359a7e8cec09b7405e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "f1707986ffc747dda0f4997108485ec3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_e052e2f6b3fe49eb972493308248b005",
+       "style": "IPY_MODEL_99ee9fb22c5046039e85d4f6344b1a87",
+       "value": "<p><b>Dashboard: </b><a href=\"/user/rsignell-usgs-h-ke-water-levels-gxgmp8cb/proxy/8787/status\" target=\"_blank\">/user/rsignell-usgs-h-ke-water-levels-gxgmp8cb/proxy/8787/status</a></p>\n"
+      }
+     },
+     "f1f974bd02ca485da5f00855978d99ca": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_83268aac72194c14a848e95024d2135c",
+       "style": "IPY_MODEL_d9962513f16d417d8138e25ab85da0b2",
+       "value": "<div style=\"padding: 0px 10px 0px 10px; text-align: right\">65 / 65</div>"
+      }
+     },
+     "f289244e80a54bcf90624e4ee5f7e717": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "IntTextModel",
+      "state": {
+       "description": "Minimum",
+       "layout": "IPY_MODEL_3ca434c698bb4a888a54af6427e3a4c7",
+       "step": 1,
+       "style": "IPY_MODEL_d491c10e7f9c4c65bf35df80c5721fd9"
+      }
+     },
+     "f2942b13497a4940b9ae59f9573dd8de": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f2c18f48ecda442a8896dc53e19daf2f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_5fed2b245bec4760b5032e5862bd90a2",
+       "style": "IPY_MODEL_8164317914ae483da528bbb0b9498798",
+       "value": "<h2>KubeCluster</h2>"
+      }
+     },
+     "f2caf0c8119b4239b008f7552412bf26": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f2cc50fbdc8040aca0eb433c183b6485": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonStyleModel",
+      "state": {}
+     },
+     "f30283674ce845f2bc15fe4f8705fc37": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f3a92cdb4d6749169038bb6226c78a7c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ButtonModel",
+      "state": {
+       "description": "Scale",
+       "layout": "IPY_MODEL_ab4827e391e94ca9858c12c5388a7791",
+       "style": "IPY_MODEL_08c0039c039d4136abae1a23fe6dfa50"
+      }
+     },
+     "f44bd6192dea4ee18bd7b5bad3c1fa6a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_c951822a4060472d813c7cc6ad574143",
+        "IPY_MODEL_e4bf2a39a6fb460baca8e2b36c4d27df",
+        "IPY_MODEL_a7900f6a21354cdaaa9dab9ecb0f67bb"
+       ],
+       "layout": "IPY_MODEL_f2caf0c8119b4239b008f7552412bf26"
+      }
+     },
+     "f450a4fb334a4e31a7957f6ef935d62a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f5c4287c7e224928a83cb404f12bcf2e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_46244b84c4fa410b957ba71e0a34cb8a",
+       "style": "IPY_MODEL_31c7164fc63141378888246dd152f9c3",
+       "value": "<div style=\"padding: 0px 10px 0px 10px; text-align: right\">4813 / 4813</div>"
+      }
+     },
+     "f7323c7f519f4836bac9bce7a3427d89": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_4acf4a412c5c4bb6854ea71b46fdee2d",
+       "style": "IPY_MODEL_254e3a2e6d2047c9ad8afbc2a2e894dc",
+       "value": "\n<div>\n  <style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n  </style>\n  <table style=\"text-align: right;\">\n    <tr> <th>Workers</th> <td>30</td></tr>\n    <tr> <th>Cores</th> <td>60</td></tr>\n    <tr> <th>Memory</th> <td>210.00 GB</td></tr>\n  </table>\n</div>\n"
+      }
+     },
+     "f860565f03c9460a9fcd197828d4a043": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f9282aa1eb984b008506c3e524a38842": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "fabd653922be4de6bc16dbf269a441fd": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_06deec34f1f64fad83e521f98f800297",
+        "IPY_MODEL_6093bd652b3f4db5a386268e9511e965"
+       ],
+       "layout": "IPY_MODEL_959d68a330a54deb9d968b825090ee8a"
+      }
+     },
+     "fad4f62c9399419993153fb961830488": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_d37fb3ecbbb14555b020111b7fb1d6e4",
+       "style": "IPY_MODEL_df5fe18cd57141db86d43128f4375603",
+       "value": "<div style=\"padding: 0px 10px 0px 10px; text-align: right\">4680 / 4680</div>"
+      }
+     },
+     "fb569e3e2e3a431a8d2e36ff98d9b5c9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "IntTextModel",
+      "state": {
+       "description": "Workers",
+       "layout": "IPY_MODEL_e305226a73c74f958ffe7d13ea6c67f9",
+       "step": 1,
+       "style": "IPY_MODEL_5ab4628605b44c2cb2f28f07277c85ba"
+      }
+     },
+     "fbf901b76b014589bcd19fb800b66b6a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_4f69a4c8c1984c66ae14dfd9e7d65601",
+       "style": "IPY_MODEL_a74db149a62140d8bdd0b3ffa3d6b9de",
+       "value": "<div style=\"padding: 0px 10px 0px 10px; text-align: right\">65 / 65</div>"
+      }
+     },
+     "fceb299bd8cb4252a54965cdf932b5d3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "ff7b8038de9740508084b810f37d68bc": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     }
+    },
+    "version_major": 2,
+    "version_minor": 0
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/intake_catalog.yml
+++ b/examples/intake_catalog.yml
@@ -1,0 +1,23 @@
+sources:
+  ike-hdf5:
+    driver: intake_xarray.xzarr.ZarrSource
+    description: 'Hurricane Ike simulation in NetCDF4/HDF5 format'
+    args:
+      storage_options:
+        ref_storage_args:
+          requester_pays: true
+        references: "s3://pangeo-data-uswest2/esip/adcirc/adcirc_01d_offsets.json"
+        target_options:
+          requester_pays: true
+        target_protocol: s3
+      urlpath: "reference://"
+
+  ike-zarr:
+    driver: zarr
+    description: "Hurricane Ike simulation in Zarr format"
+    args:
+      urlpath: s3://pangeo-data-uswest2/esip/adcirc/adcirc_01d
+      consolidated: true
+      storage_options:
+        requester_pays: true
+     


### PR DESCRIPTION
Here is the [rendered notebook](https://nbviewer.jupyter.org/gist/rsignell-usgs/cd7821fa728512853e75feb1912058e0) example.
 
I've been saying that reading HDF5  is not significantly different than reading zarr, but it's actually about 20% slower for this example.   With our original test, the times were not significantly different.   @martindurant, Would you expect our new mapping approach to be slower?