### PR TITLE
use latest packages from conda-forge

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -2,7 +2,6 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.8
   - dask
   - dask-gateway
   - fsspec
@@ -14,6 +13,3 @@ dependencies:
   - s3fs
   - xarray
   - zarr
-  - pip:
-      - "git+https://github.com/intake/filesystem_spec"
-      - "git+https://github.com/dask/s3fs"


### PR DESCRIPTION
Now that `s3fs=0.5.2` and `fsspec=0.8.5` are out we don't need pip install from master!
Hurray @martindurant !