### PR TITLE
Remove explicit import of numcodecs.Shuffle

### DIFF
--- a/fsspec_reference_maker/hdf.py
+++ b/fsspec_reference_maker/hdf.py
@@ -8,7 +8,7 @@ import numpy as np
 import h5py
 import zarr
 from zarr.meta import encode_fill_value
-from numcodecs import Zlib, Shuffle
+import numcodecs
 import fsspec
 import fsspec.utils
 import fsspec.core
@@ -160,14 +160,14 @@ class SingleHdf5ToZarr:
                 raise RuntimeError(
                     f'{h5obj.name} uses unsupported HDF5 filters')
             if h5obj.compression == 'gzip':
-                compression = Zlib(level=h5obj.compression_opts)
+                compression = numcodecs.Zlib(level=h5obj.compression_opts)
             else:
                 compression = None
             
             # Add filter for shuffle
             filters = []
             if h5obj.shuffle:
-                filters.append(Shuffle(elementsize=h5obj.dtype.itemsize))
+                filters.append(numcodecs.Shuffle(elementsize=h5obj.dtype.itemsize))
 
             # Get storage info of this HDF5 dataset...
             cinfo = self._storage_info(h5obj)


### PR DESCRIPTION
In our meeting last week we discussed removing the direct import `from numcodecs import Zlib, Shuffle` which would fail on `numcodecs < 0.8.0`. 

Now, importing `fsspec-reference-maker.SingleHdf5ToZarr` will not fail if numcodecs is at an older version, but there will still be an import error if a user tries to open a Shuffle compressed data file without the latest version of numcodecs.