### PR TITLE
Removed reference to `xarray` arg

### DIFF
--- a/fsspec_reference_maker/hdf.py
+++ b/fsspec_reference_maker/hdf.py
@@ -45,7 +45,6 @@ class SingleHdf5ToZarr:
         # Open HDF5 file in read mode...
         lggr.debug(f'HDF5 file: {h5f}')
         self.input_file = h5f
-#         lggr.debug(f'xarray: {xarray}')
         self.spec = spec
         self.inline = inline_threshold
         self._h5f = h5py.File(h5f, mode='r')

--- a/fsspec_reference_maker/hdf.py
+++ b/fsspec_reference_maker/hdf.py
@@ -45,7 +45,7 @@ class SingleHdf5ToZarr:
         # Open HDF5 file in read mode...
         lggr.debug(f'HDF5 file: {h5f}')
         self.input_file = h5f
-        lggr.debug(f'xarray: {xarray}')
+#         lggr.debug(f'xarray: {xarray}')
         self.spec = spec
         self.inline = inline_threshold
         self._h5f = h5py.File(h5f, mode='r')


### PR DESCRIPTION
There was a reference to the `xarray` arg in `SingleHdf5ToZarr()` log that causes an error since `xarray=True/False` was removed as an argument in `__init__()`