### PR TITLE
rewrite MultiZarrToZarr to always use xr.concat

### DIFF
--- a/fsspec_reference_maker/grib2.py
+++ b/fsspec_reference_maker/grib2.py
@@ -197,5 +197,6 @@ def example_multi(filter={'typeOfLevel': 'heightAboveGround', 'level': 2}):
     #  'hrrr.t04z.wrfsfcf01.json',
     #  'hrrr.t05z.wrfsfcf01.json',
     #  'hrrr.t06z.wrfsfcf01.json']
-    # mzz = MultiZarrToZarr(files, remote_protocol="s3", remote_options={"anon": True}, with_mf='time')
+    # mzz = MultiZarrToZarr(files, remote_protocol="s3", remote_options={"anon": True}
+    #                       concat_kwargs={"dim": 'time'})
     # mzz.translate("hrrr.total.json")

--- a/fsspec_reference_maker/hdf.py
+++ b/fsspec_reference_maker/hdf.py
@@ -290,7 +290,7 @@ def example_single():
     )
     fsspec.utils.setup_logging(logger=lggr)
     with fsspec.open(url, **so) as f:
-        h5chunks = SingleHdf5ToZarr(f, url, xarray=True)
+        h5chunks = SingleHdf5ToZarr(f, url)
         return h5chunks.translate()
 
 


### PR DESCRIPTION
@ lsterzinger @rsignell-usgs - this applies what we discussed, to make to xr.concat explicit and pass a separate set of options to it. If this feels OK, I'll update the docstrings then.
`example_ensamble()` runs fine with this, quite fast (with the "minimal" and "override" arguments)