### PR TITLE
Improved error messages

### DIFF
--- a/fsspec_reference_maker/hdf.py
+++ b/fsspec_reference_maker/hdf.py
@@ -154,10 +154,18 @@ class SingleHdf5ToZarr:
                     f'{h5obj.shape} {h5obj.dtype} {h5obj.nbytes} bytes>')
                 return
 
-            if (h5obj.scaleoffset or h5obj.fletcher32 or
-                    h5obj.compression in ('szip', 'lzf')):
+            #
+            # check for unsupported dataset properties
+            #
+            if h5obj.scaleoffset:
                 raise RuntimeError(
-                    f'{h5obj.name} uses unsupported HDF5 filters')
+                    f'{h5obj.name} uses HDF5 scaleoffset filter - not supported by reference-maker')
+            if h5obj.fletcher32:
+                raise RuntimeError(
+                    f'{h5obj.name} uses fletcher32 checksum - not supported by reference-maker')
+            if h5obj.compression in ('szip', 'lzf'):
+                raise RuntimeError(
+                    f'{h5obj.name} uses szip or lzf compression - not supported by reference-maker')
             if h5obj.compression == 'gzip':
                 compression = numcodecs.Zlib(level=h5obj.compression_opts)
             else:

--- a/fsspec_reference_maker/hdf.py
+++ b/fsspec_reference_maker/hdf.py
@@ -155,7 +155,7 @@ class SingleHdf5ToZarr:
                 return
 
             #
-            # check for unsupported dataset properties
+            # check for unsupported HDF encoding/filters
             #
             if h5obj.scaleoffset:
                 raise RuntimeError(


### PR DESCRIPTION
We are testing fsspec-reference-maker on many HDF5 files and most of the break. It is helpful to know more about why they break so I added test-specific error messages.