### PR TITLE
Added support for phony dims

### DIFF
--- a/fsspec_reference_maker/hdf.py
+++ b/fsspec_reference_maker/hdf.py
@@ -237,6 +237,13 @@ class SingleHdf5ToZarr:
                     raise RuntimeError(
                         f'{dset.name}: {len(dset.dims[n])} '
                         f'dimension scales attached to dimension #{n}')
+                elif num_scales == 0:
+                    # Some HDF5 files do not have dimension scales. 
+                    # If this is the case, `num_scales` will be 0.
+                    # In this case, we mimic netCDF4 and assign phony dimension names.
+                    # See https://github.com/intake/fsspec-reference-maker/issues/41
+
+                    dims.append(f"phony_dim_{n}")
         return dims
 
     def _storage_info(self, dset: h5py.Dataset) -> dict:


### PR DESCRIPTION
This fixes #41 

If `num_scales == 0`, then we detected dimensions but could not access names. This will add `phony_dim_x` as dimension names. 

Tested on 'az://modis-006/VNP14A1/08/04/2020001/VNP14A1.A2020001.h08v04.001.2020003132203.h5'