### PR TITLE
Add ujson requirement to docs build

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,3 +7,4 @@ h5py
 numcodecs
 xarray
 zarr
+ujson


### PR DESCRIPTION
This prevented autodoc from updating docs from docstrings in source