### PR TITLE
Do not use concat if accum_dim is 1d

### DIFF
--- a/fsspec_reference_maker/combine.py
+++ b/fsspec_reference_maker/combine.py
@@ -186,7 +186,12 @@ class MultiZarrToZarr:
             accum[accum_dim] = [np.array(a, dtype="M8") for a in accum[accum_dim]]
             attr.pop('units')
             attr.pop('calendar')
-        acc = np.concatenate(accum[accum_dim]).squeeze()
+    
+        if np.array(accum[accum_dim]).ndim == 1:
+            acc = accum[accum_dim]
+        else:
+            acc = np.concatenate(accum[accum_dim]).squeeze()
+
         acc_len = len(acc)
         logger.debug("write coords array")
         arr = z.create_dataset(name=accum_dim,

--- a/fsspec_reference_maker/combine.py
+++ b/fsspec_reference_maker/combine.py
@@ -187,10 +187,7 @@ class MultiZarrToZarr:
             attr.pop('units')
             attr.pop('calendar')
     
-        if np.array(accum[accum_dim]).ndim == 1:
-            acc = accum[accum_dim]
-        else:
-            acc = np.concatenate(accum[accum_dim]).squeeze()
+        acc = np.concatenate([np.atleast_1d(a) for a in accum[accum_dim]]).squeeze()
 
         acc_len = len(acc)
         logger.debug("write coords array")


### PR DESCRIPTION
I was running into an error when combining datasets along a time axis.

```
ValueError: zero-dimensional arrays cannot be concatenated
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<timed eval> in <module>

~/anaconda3/envs/fsspec-tutorial/lib/python3.8/site-packages/fsspec_reference_maker/combine.py in translate(self, outpath)
     61 
     62         ds, ds0, fss = self._determine_dims()
---> 63         out = self._build_output(ds, ds0, fss)
     64         self.output = self._consolidate(out)
     65 

~/anaconda3/envs/fsspec-tutorial/lib/python3.8/site-packages/fsspec_reference_maker/combine.py in _build_output(self, ds, ds0, fss)
    187             attr.pop('units')
    188             attr.pop('calendar')
--> 189         acc = np.concatenate(accum[accum_dim]).squeeze()
    190         acc_len = len(acc)
    191         logger.debug("write coords array")

<__array_function__ internals> in concatenate(*args, **kwargs)

ValueError: zero-dimensional arrays cannot be concatenated
```

`accum[accum_dim]` is a list, so I check for number of dimensions by converting it to a numpy array and checking with `.ndim`. If it's equal to 1, `acc = accum[dim]`. 

I'm not 100% sure if this is a _good_ fix, but it fixed my error. There's probably a better way of doing this