### PR TITLE
Add support for list-of-dict input to MultiZarrToZarr

### DIFF
--- a/fsspec_reference_maker/combine.py
+++ b/fsspec_reference_maker/combine.py
@@ -246,16 +246,27 @@ class MultiZarrToZarr:
 
     def _determine_dims(self):
         logger.debug("open mappers")
-        with fsspec.open_files(self.path, **self.storage_options) as ofs:
+
+        if type(self.path[0]) == dict:
             fss = [
                 fsspec.filesystem(
-                    "reference", fo=json.load(of),
+                    "reference", fo=d,
                     remote_protocol=self.remote_protocol,
                     remote_options=self.remote_options
-                ) for of in ofs
+                ) for d in self.path
             ]
-            self.fs = fss[0].fs
-            mappers = [fs.get_mapper("") for fs in fss]
+            
+        else:
+            with fsspec.open_files(self.path, **self.storage_options) as ofs:
+                fss = [
+                    fsspec.filesystem(
+                        "reference", fo=json.load(of),
+                        remote_protocol=self.remote_protocol,
+                        remote_options=self.remote_options
+                    ) for of in ofs
+                ]
+        self.fs = fss[0].fs
+        mappers = [fs.get_mapper("") for fs in fss]
 
         logger.debug("open first two datasets")
         xr_kwargs_copy = self.xr_kwargs.copy()

--- a/fsspec_reference_maker/combine.py
+++ b/fsspec_reference_maker/combine.py
@@ -248,7 +248,8 @@ class MultiZarrToZarr:
         logger.debug("open mappers")
 
         # If self.path is a list of dictionaries, pass them directly to fsspec.filesystem
-        if type(self.path[0]) == dict:
+        import collections.abc
+        if isinstance(self.path[0], collections.abc.Mapping):
             fo_list = self.path
         
         # If self.path is list of files, open the files and load the json as a dictionary
@@ -322,4 +323,3 @@ def example_ensemble():
         xarray_concat_args=concat_kwargs
     )
     mzz.translate("output.zarr")
-


### PR DESCRIPTION
This PR creates an `fo_list` to pass to `fsspec.filesystem`. Since `fsspec_filesystem` is able to read python dicts directly, if `self.path[0]` is a dict, then fo_list is just a duplicate of that list. 

If `self.path[0]` is not a dict, then it will open the files and read the jsons as dicts, which are added to `fo_list

I tested this by loading some json files and converting them to dictionaries:

```python
json_list = sorted(glob('./jsons/*'))

dict_list = [ujson.load(f) for f in [open(inf) for inf in json_list]]
```
Then running `MultiZarrToZarr` by passing in the dictionary list:
```python
mzz = MultiZarrToZarr(
    dict_list,
    remote_protocol="s3",
    remote_options={'anon':True},
    xarray_open_kwargs={
        "decode_cf" : False,
        "mask_and_scale" : False,
        "decode_times" : False,
        "decode_timedelta" : False,
        "use_cftime" : False,
        "decode_coords" : False
    },
    xarray_concat_args={
        'data_vars' : 'minimal',
        'coords' : 'minimal',
        'compat' : 'override',
        'join' : 'override', 
        'combine_attrs' : 'override',
        'dim' : 't'
    }
)

d = mzz.translate()
print(d)
```