### PR TITLE
Replace empty h5py empty object with empty string.

### DIFF
--- a/fsspec_reference_maker/hdf.py
+++ b/fsspec_reference_maker/hdf.py
@@ -132,6 +132,8 @@ class SingleHdf5ToZarr:
                         v = v.tolist()
                 else:
                     v = v.tolist()
+            elif isinstance(v, h5py._hl.base.Empty):
+                v = ""
             if v == 'DIMENSION_SCALE':
                 continue
             try:


### PR DESCRIPTION
Json can not handle `h5py.Empty` object, thus if a NetCDF file contains that, `SingleHdf5ToZarr.translate` fails.   We change that object to `""` as Xarray does.  Work done thanks to  @keewis 